### PR TITLE
JSON string parsing speed improvements

### DIFF
--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -40,6 +40,7 @@ class JSONBench
         "Lorem Ipsum dolor sit amet",
         "Lorem Ipsum dolor sit amet"
     ],
+    "alotmoretext": "Fuga iusto dolores ipsam. Qui excepturi veniam iste autem ducimus porro et voluptas. Veniam veniam ducimus cumque facere repudiandae corrupti sint quas. Cupiditate asperiores iure omnis dolores nihil asperiores qui quo. Assumenda quia iure deserunt deserunt. Perspiciatis velit quia et.\n\nExplicabo non dolores aut facere. Perferendis in est voluptate. Et laboriosam et autem voluptatum rem nam et aut. Voluptatem praesentium et earum fugit accusamus tempore consectetur natus. Beatae sunt nisi rerum blanditiis consequatur rerum ut.\n\nIure ipsa sit assumenda. Vitae nisi qui vero. Eveniet cum aliquam molestiae molestias. Nisi aut ea alias quo ea voluptatem. Minus ea mollitia quis.",
     "description": "The easiest way to build robust parsers in PHP.",
     "keywords": [
         "parser",

--- a/benchmarks/JSONBench.php
+++ b/benchmarks/JSONBench.php
@@ -21,6 +21,25 @@ class JSONBench
 {
     "name": "mathiasverraes/parsica",
     "type": "library",
+    "alotoftext": [
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet",
+        "Lorem Ipsum dolor sit amet"
+    ],
     "description": "The easiest way to build robust parsers in PHP.",
     "keywords": [
         "parser",

--- a/src/JSON/JSON.php
+++ b/src/JSON/JSON.php
@@ -186,6 +186,7 @@ final class JSON
                 char('"'),
                 zeroOrMore(
                     choice(
+                        satisfy(fn(string $char): bool => !in_array($char, ['"', '\\'])),
                         char("\\")->followedBy(
                             choice(
                                 char("\"")->map(fn($_) => '"'),
@@ -198,8 +199,7 @@ final class JSON
                                 char("t")->map(fn($_) => "\t"),
                                 char("u")->sequence(repeat(4, hexDigitChar()))->map(fn($o) => mb_chr(hexdec($o))),
                             )
-                        ),
-                        anySingleBut('"') // @TODO is a backslash  that is not one of the escapes above legal?
+                        )
                     )
                 )
             )->map(fn($o): string => (string)$o) // because the empty json string returns null

--- a/src/JSON/JSON.php
+++ b/src/JSON/JSON.php
@@ -27,6 +27,7 @@ use function Verraes\Parsica\{any,
     satisfy,
     sepBy,
     string,
+    takeWhile,
     zeroOrMore};
 
 /**
@@ -153,7 +154,7 @@ final class JSON
      */
     public static function ws(): Parser
     {
-        return zeroOrMore(satisfy(isCharCode([0x20, 0x0A, 0x0D, 0x09])))->voidLeft(null)
+        return takeWhile(isCharCode([0x20, 0x0A, 0x0D, 0x09]))->voidLeft(null)
             ->label('whitespace');
     }
 

--- a/src/JSON/JSON.php
+++ b/src/JSON/JSON.php
@@ -185,15 +185,19 @@ final class JSON
                 char('"'),
                 zeroOrMore(
                     choice(
-                        string("\\\"")->map(fn($_) => '"'),
-                        string("\\\\")->map(fn($_) => '\\'),
-                        string("\\/")->map(fn($_) => '/'),
-                        string("\\b")->map(fn($_) => mb_chr(8)),
-                        string("\\f")->map(fn($_) => mb_chr(12)),
-                        string("\\n")->map(fn($_) => "\n"),
-                        string("\\r")->map(fn($_) => "\r"),
-                        string("\\t")->map(fn($_) => "\t"),
-                        string("\\u")->sequence(repeat(4, hexDigitChar()))->map(fn($o) => mb_chr(hexdec($o))),
+                        char("\\")->followedBy(
+                            choice(
+                                char("\"")->map(fn($_) => '"'),
+                                char("\\")->map(fn($_) => '\\'),
+                                char("/")->map(fn($_) => '/'),
+                                char("b")->map(fn($_) => mb_chr(8)),
+                                char("f")->map(fn($_) => mb_chr(12)),
+                                char("n")->map(fn($_) => "\n"),
+                                char("r")->map(fn($_) => "\r"),
+                                char("t")->map(fn($_) => "\t"),
+                                char("u")->sequence(repeat(4, hexDigitChar()))->map(fn($o) => mb_chr(hexdec($o))),
+                            )
+                        ),
                         anySingleBut('"') // @TODO is a backslash  that is not one of the escapes above legal?
                     )
                 )

--- a/src/numeric.php
+++ b/src/numeric.php
@@ -24,7 +24,7 @@ function integer(): Parser
     $zeroNine = digitChar();
     $oneNine = oneOfS("123456789");
     $minus = char('-');
-    $digits = atLeastOne($zeroNine);
+    $digits = takeWhile1(isDigit())->label('at least one 0-9');
     /** @var Parser<string> $parser */
     $parser = choice(
         $minus->append($oneNine)->append($digits),
@@ -48,8 +48,7 @@ function integer(): Parser
  */
 function float(): Parser
 {
-    $zeroNine = digitChar();
-    $digits = atLeastOne($zeroNine);
+    $digits = takeWhile1(isDigit())->label('at least one 0-9');
     $fraction = char('.')->append($digits);
     $sign = char('+')->or(char('-'))->or(pure('+'));
     $exponent = assemble(

--- a/tests/JSON/JSONTest.php
+++ b/tests/JSON/JSONTest.php
@@ -27,6 +27,7 @@ final class JSONTest extends TestCase
             [' [ { " a b  " : " c  d " } ] '],
             [' [ { " a b  " : " c  d " } , { "ef" : "gh" } ] '],
             ['"some weird chars \\n in \\t strings \\u9999 should do it"'],
+            ['"this \\\\ is just a backslash"'],
             [<<<JSON
                 [
                     -1.23,

--- a/tests/JSON/JSONTest.php
+++ b/tests/JSON/JSONTest.php
@@ -26,6 +26,7 @@ final class JSONTest extends TestCase
             [' { " a b  " : " c  d " } '],
             [' [ { " a b  " : " c  d " } ] '],
             [' [ { " a b  " : " c  d " } , { "ef" : "gh" } ] '],
+            ['"some weird chars \\n in \\t strings \\u9999 should do it"'],
             [<<<JSON
                 [
                     -1.23,


### PR DESCRIPTION
While testing some things in the JSON parser benchmarks when writing [this](https://github.com/mathiasverraes/parsica/issues/17#issuecomment-753486533), i found these:


## ⚡️ Write character parsers instead of string parsers

Since we're looking for a backslash, followed by a character from a list
of special escaped characters, we can make this a simpler parse than
looking for the explicit combinations as strings. This makes us
backtrack less.

This results in a x3 speed improvement for parsing strings.


## ⚡️ Using `takeWhile(f)` is faster than `zeroOrMore(satisfy(f))` combo

Because it doesn't have to run the parser completely, every time. It can
just rely on the stream implementation. This results in a ± x1.25 speed
improvement according to some benchmarks I did.


## ⚡️ Accept any character in JSON Strings instead of the special ones first

Instead of looking for special characters first, and backtracking if we
don't find them, look for the accepted ones first, and parse the special
ones only if that fails.

This results in a x1.35 speed improvement in the benchmarks I did.


